### PR TITLE
fix config deployment error and bottlenecks

### DIFF
--- a/kvm-cluster/roles/fiehnlab/eureka/tasks/main.yml
+++ b/kvm-cluster/roles/fiehnlab/eureka/tasks/main.yml
@@ -1,4 +1,14 @@
 ---
+- name: "removing existing Eureka stack"
+  when:
+    - "'docker_swarm_manager' in group_names"
+  docker_stack:
+    state: absent
+    name: eureka
+  tags:
+    - deploy_eureka
+
+
 - name: "deploying Eureka"
   when:
     - "'docker_swarm_manager' in group_names"

--- a/kvm-cluster/vm_prod_cluster.yml
+++ b/kvm-cluster/vm_prod_cluster.yml
@@ -77,16 +77,10 @@
         name: fiehnlab/cfb
 
     - import_role:
-        name: fiehnlab/chemrich
-
-    - import_role:
         name: fiehnlab/cts
 
     - import_role:
         name: fiehnlab/eureka
-
-    - import_role:
-        name: fiehnlab/exposome
 
     - import_role:
         name: fiehnlab/mida
@@ -99,9 +93,6 @@
 
     - import_role:
         name: fiehnlab/metcor
-
-    - import_role:
-        name: fiehnlab/metda
 
     - import_role:
         name: fiehnlab/minix
@@ -132,6 +123,18 @@
 
     - import_role:
         name: fiehnlab/splash
+
+
+    # services with large images or long startup time that can cause a bottleneck in the
+    # proxy's ability to identify other services
+    - import_role:
+        name: fiehnlab/chemrich
+
+    - import_role:
+        name: fiehnlab/exposome
+
+    - import_role:
+        name: fiehnlab/metda
 
     - import_role:
         name: fiehnlab/stats


### PR DESCRIPTION
- prevent deployment from failing due to changes in docker configs
- reorder deployment of fiehnlab services so that stacks with largest images and longest startup times are started last, which avoids blocking the flow proxy from updating its haproxy config